### PR TITLE
`components` is not required.

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -6,7 +6,7 @@ var Converter = require('./Converter');
 module.exports = React.createClass({
 	propTypes: {
 		markdown: React.PropTypes.string,
-		components: React.PropTypes.objectOf(React.PropTypes.element).isRequired
+		components: React.PropTypes.objectOf(React.PropTypes.element)
 	},
 
 	render: function() {


### PR DESCRIPTION
It eliminates the warning message shown in dev mode when `components` is left out as in the example. 