### PR TITLE
Add table tag support

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -19,13 +19,40 @@ module.exports = function Converter(options) {
 
 	this._converter = new showdown.Converter(options);
 
+	// remove newlines from table tags
+	this._converter.listen('tables.after', function(_, text) {
+		var result = text;
+		var tags = ['table', 'thead', 'tbody', 'tfoot', 'th', 'tr', 'td'];
+		tags.forEach(function(tag) {
+			result = result
+				.replace(new RegExp('\n<' + tag, 'g'), '<' + tag)
+				.replace(new RegExp('\n</' + tag, 'g'), '</' + tag);
+		});
+		return result;
+	});
+
 	this._components = {};
 	for (var key in (options && options.components || {})) {
 		this._components[key.toLowerCase()] = options.components[key];
 	}
 
+	// remove the style attribute and apply it after component mount
+	function fixStyle(element) {
+		if (!element.attribs.style) {
+			return;
+		}
+		var style = element.attribs.style;
+		delete element.attribs.style;
+		element.attribs.ref = function(c) {
+			if (c) {
+				c.setAttribute('style', style);
+			}
+		};
+	}
+
 	this._mapElement = function(element) {
 		if (element.type === 'tag') {
+			fixStyle(element);
 			var component = this._components[element.name] || element.name;
 			return React.createElement(component, element.attribs, this._mapElements(element.children));
 		} else if (element.type === 'text') {

--- a/test/ConverterTest.js
+++ b/test/ConverterTest.js
@@ -94,5 +94,13 @@ describe('Converter', function() {
 			var expectedHtml = '<div><h1 id="hello">Hello</h1>\n</div>';
 			assert.equal(actualHtml, expectedHtml);
 		});
+
+		it('should convert markdown to table tags', function() {
+			var converter = new Converter({ tables: true });
+			var reactElement = converter.convert('|h1|h2|h3|\n|:--|:--:|--:|\n|*foo*|**bar**|baz|');
+			var actualHtml = renderToStaticMarkup(reactElement);
+			var expectedHtml = '<table><thead><tr><th>h1</th><th>h2</th><th>h3</th></tr></thead><tbody><tr><td><em>foo</em></td><td><strong>bar</strong></td><td>baz</td></tr></tbody></table>';
+			assert.equal(actualHtml, expectedHtml);
+		});
 	});
 });

--- a/test/ElementTest.js
+++ b/test/ElementTest.js
@@ -74,4 +74,11 @@ describe('Element', function() {
 		var expectedHtml = '<div><h1 id="hello">Hello</h1>\n</div>';
 		assert.equal(actualHtml, expectedHtml);
 	});
+
+	it('should render markdown to table tags', function() {
+		var reactElement = React.createElement(Element, { markdown: '|h1|h2|h3|\n|:--|:--:|--:|\n|*foo*|**bar**|baz|', tables: true });
+		var actualHtml = renderToStaticMarkup(reactElement);
+		var expectedHtml = '<table><thead><tr><th>h1</th><th>h2</th><th>h3</th></tr></thead><tbody><tr><td><em>foo</em></td><td><strong>bar</strong></td><td>baz</td></tr></tbody></table>';
+		assert.equal(actualHtml, expectedHtml);
+	});
 });


### PR DESCRIPTION
## Request

I want to use tables with react-showdown.

## Problem

I have issues when use tables by passing `tables` options.

```js
  const converter = new Converter({
    tables: true
  })
```

![2016-11-21 15 19 08](https://cloud.githubusercontent.com/assets/5355966/20472641/a1b46634-affe-11e6-84a0-00957f3fb97e.png)

- First, showdown output table tags with newlines but React.createClass warn it.
- Second, table cells can be aligned by css but React doesn't expect css string.

## Solution

1. remove newlines from table tags after convert at `tables.after`
2. remove the style attribute and apply it after component mount
