### PR TITLE
Convert style string to object instead of using ref

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -41,18 +41,32 @@ module.exports = function Converter(options) {
 		delete element.attribs.class;
 	}
 
+	function parseStyles(styles) {
+		// taken from https://gist.github.com/goldhand/70de06a3bdbdb51565878ad1ee37e92b
+		return styles
+			.split(';')
+			.filter(function(style){
+				return style.split(':')[0] && style.split(':')[1];
+			})
+			.map(function(style) {
+				return [
+					style.split(':')[0].trim().replace(/-./g, function(c) { return c.substr(1).toUpperCase(); }),
+					style.split(':')[1].trim()
+				];
+			})
+			.reduce(function(styleObj, style) {
+				var result = Object.assign({}, styleObj);
+				result[style[0]] = style[1];
+				return result;
+			}, {});
+	}
+
 	// remove the style attribute and apply it after component mount
 	function fixStyle(element) {
-		if (!element.attribs.style) {
-			return;
-		}
 		var style = element.attribs.style;
-		delete element.attribs.style;
-		element.attribs.ref = function(c) {
-			if (c) {
-				c.setAttribute('style', style);
-			}
-		};
+		if (style) {
+			element.attribs.style = parseStyles(style);
+		}
 	}
 
 	this._mapElement = function(element) {

--- a/test/ConverterTest.js
+++ b/test/ConverterTest.js
@@ -22,6 +22,12 @@ var MyComponent = createClass({
 	}
 });
 
+var ThComponent = createClass({
+	render: function() {
+		return React.createElement('th', this.props);
+	}
+});
+
 describe('Converter', function() {
 	describe('Object', function() {
 		it('should be a function', function() {
@@ -103,7 +109,7 @@ describe('Converter', function() {
 			var converter = new Converter({ tables: true });
 			var reactElement = converter.convert('|h1|h2|h3|\n|:--|:--:|--:|\n|*foo*|**bar**|baz|');
 			var actualHtml = renderToStaticMarkup(reactElement);
-			var expectedHtml = '<table><thead><tr><th>h1</th><th>h2</th><th>h3</th></tr></thead><tbody><tr><td><em>foo</em></td><td><strong>bar</strong></td><td>baz</td></tr></tbody></table>';
+			var expectedHtml = '<table><thead><tr><th style="text-align:left;">h1</th><th style="text-align:center;">h2</th><th style="text-align:right;">h3</th></tr></thead><tbody><tr><td style="text-align:left;"><em>foo</em></td><td style="text-align:center;"><strong>bar</strong></td><td style="text-align:right;">baz</td></tr></tbody></table>';
 			assert.equal(actualHtml, expectedHtml);
 		});
 
@@ -126,6 +132,14 @@ describe('Converter', function() {
 			var reactElement = converter.convert('<span class="foo">text</span><MyComponent markdown="1" tag="strong"/>');
 			var actualHtml = renderToStaticMarkup(reactElement);
 			var expectedHtml = '<p><span class="foo">text</span><strong></strong></p>';
+			assert.equal(actualHtml, expectedHtml);
+		});
+
+		it('should render custom components with style attribute', function() {
+			var converter = new Converter({ components: { th: ThComponent }, tables: true });
+			var reactElement = converter.convert('| a | b |\n|:--|---|\n| 1 | 2 |');
+			var actualHtml = renderToStaticMarkup(reactElement);
+			var expectedHtml = '<table><thead><tr><th style="text-align:left;">a</th><th>b</th></tr></thead><tbody><tr><td style="text-align:left;">1</td><td>2</td></tr></tbody></table>';
 			assert.equal(actualHtml, expectedHtml);
 		});
 	});

--- a/test/ElementTest.js
+++ b/test/ElementTest.js
@@ -79,7 +79,7 @@ describe('Element', function() {
 	it('should render markdown to table tags', function() {
 		var reactElement = React.createElement(Element, { markdown: '|h1|h2|h3|\n|:--|:--:|--:|\n|*foo*|**bar**|baz|', tables: true });
 		var actualHtml = renderToStaticMarkup(reactElement);
-		var expectedHtml = '<table><thead><tr><th>h1</th><th>h2</th><th>h3</th></tr></thead><tbody><tr><td><em>foo</em></td><td><strong>bar</strong></td><td>baz</td></tr></tbody></table>';
+		var expectedHtml = '<table><thead><tr><th style="text-align:left;">h1</th><th style="text-align:center;">h2</th><th style="text-align:right;">h3</th></tr></thead><tbody><tr><td style="text-align:left;"><em>foo</em></td><td style="text-align:center;"><strong>bar</strong></td><td style="text-align:right;">baz</td></tr></tbody></table>';
 		assert.equal(actualHtml, expectedHtml);
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/jerolimov/react-showdown/issues/14

Note that instead of handling these edge cases caused by parsing the resulting html with htmlparser2 it makes more sense to use a library for that, e.g. https://github.com/wrakky/react-html-parser