### PR TITLE
Enable adding inline styles with HTML style tags

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -1,7 +1,7 @@
 /*eslint no-console: 0*/
 
 var React = require('react');
-var showdown  = require('showdown');
+var showdown = require('showdown');
 var htmlparser = require('htmlparser2');
 
 /**
@@ -55,6 +55,24 @@ module.exports = function Converter(options) {
 		};
 	}
 
+	// render inline-styling the react way
+	// return ture or false based on if the data was formed correctly
+	function fixStyleTag(element) {
+		if (
+			!(
+				element.children &&
+				element.children.length === 1 &&
+				element.children[0].type === 'text' &&
+				element.children[0].data
+			)
+		) {
+			return false;
+		}
+		element.attribs.dangerouslySetInnerHTML = { __html: element.children[0].data };
+		delete element.data;
+		return true;
+	}
+
 	this._mapElement = function(element) {
 		if (element.type === 'tag') {
 			fixStyle(element);
@@ -69,6 +87,13 @@ module.exports = function Converter(options) {
 			return React.createElement(component, element.attribs, this._mapElements(element.children));
 		} else if (element.type === 'text') {
 			return element.data;
+		} else if (element.type === 'style') {
+			if (fixStyleTag(element)) {
+				return React.createElement(element.name, element.attribs);
+			}
+			// if casting failed, return nothing;
+			console.warn('Warning: Could not map style-tag. Please make sure to use only CSS in the innerHTML.');
+			return null;
 		} else if (element.type === 'comment') {
 			// noop
 			return null;

--- a/test/ConverterTest.js
+++ b/test/ConverterTest.js
@@ -128,5 +128,21 @@ describe('Converter', function() {
 			var expectedHtml = '<p><span class="foo">text</span><strong></strong></p>';
 			assert.equal(actualHtml, expectedHtml);
 		});
+
+		it('should render inline styles', function() {
+			var converter = new Converter();
+			var reactElement = converter.convert('<style>body { color: black; }</style>\nMore content');
+			var actualHtml = renderToStaticMarkup(reactElement);
+			var expectedHtml = '<div><style>body { color: black; }</style>\n<p>More content</p></div>';
+			assert.equal(actualHtml, expectedHtml);
+		});
+
+		it('should not render empty inline styles', function() {
+			var converter = new Converter();
+			var reactElement = converter.convert('<style></style>\nMore content');
+			var actualHtml = renderToStaticMarkup(reactElement);
+			var expectedHtml = '<div>\n<p>More content</p></div>';
+			assert.equal(actualHtml, expectedHtml);
+		});
 	});
 });


### PR DESCRIPTION
**Enable adding inline styles with HTML style tags**

Does what the title says - style tags are rendered verbatim, using React's innerHTML feature.

Let me know if this is okay or if you'd like any changes. (Or if you don't want to have this feature in the codebase)