### PR TITLE
feat: add option for sanitizing the parsed html

### DIFF
--- a/src/MarkdownView.tsx
+++ b/src/MarkdownView.tsx
@@ -19,6 +19,7 @@ export interface MarkdownViewProps {
   dangerouslySetInnerHTML?: boolean;
   flavor?: Flavor;
   markdown: string;
+  sanitizeHtml?: (html: string) => string;
   markup?: string;
   options?: ConverterOptions;
   extensions?: ShowdownExtension[];
@@ -37,6 +38,7 @@ export default function MarkdownView(props: MarkdownViewProps): ReactElement {
     options,
     extensions,
     components,
+    sanitizeHtml,
     ...otherProps
   } = props;
 
@@ -122,7 +124,10 @@ export default function MarkdownView(props: MarkdownViewProps): ReactElement {
     converter.addExtension(extensions);
   }
 
-  const html = converter.makeHtml(markdown ?? markup);
+  let html = converter.makeHtml(markdown ?? markup);
+  if (sanitizeHtml) {
+    html = sanitizeHtml(html);
+  }
 
   if (dangerouslySetInnerHTML) {
     return <div dangerouslySetInnerHTML={{ __html: html }} />;


### PR DESCRIPTION
This simply allows providing a function that can be used for sanitizing the HTML content. E.g. by using the `sanitize-html` module from npm. It makes sense to do the sanitizing post converting the markdown to HTML as there are no mature libraries for escaping markdown that is mixed with HTML.